### PR TITLE
add fbo pool for rendergraph

### DIFF
--- a/src/render-graph/effect-composer.ts
+++ b/src/render-graph/effect-composer.ts
@@ -11,6 +11,10 @@ export class EffectComposer {
   constructor(engine: RenderEngine) {
     this.engine = engine;
     this.framebufferPool = new FrameBufferPool(this.engine);
+
+    this.engine.resizeObservable.add(() => {
+      this.keptFramebuffer.clear();
+    })
   }
 
   private engine: RenderEngine;
@@ -21,6 +25,10 @@ export class EffectComposer {
 
   private keptFramebuffer: Map<RenderTargetNode, GLFramebuffer> = new Map();
   private framebufferDropList: RenderTargetNode[][] = [];
+
+  getFramebuffer(node: RenderTargetNode) {
+    return this.keptFramebuffer.get(node)
+  }
 
   render(engine: RenderEngine, graph: RenderGraph) {
     this.passes.forEach((pass, index) => {

--- a/src/render-graph/effect-composer.ts
+++ b/src/render-graph/effect-composer.ts
@@ -39,8 +39,7 @@ export class EffectComposer {
         framebuffer = this.framebufferPool.requestFramebuffer(output)
       }
 
-      pass.uniformNameFBOMap.forEach((targetName, uniformName) => {
-        const targetDepend = graph.getRenderTargetDependence(targetName);
+      pass.uniformRenderTargetNodeMap.forEach((targetDepend, uniformName) => {
         let inputFBO = this.keptFramebuffer.get(targetDepend);
 
         // if input not exist, its never initialized(empty fbo). created now!
@@ -87,7 +86,7 @@ export class EffectComposer {
       }
       for (let i = passes.length - 1; i > index; i--) {
         const passMaybeUsed = passes[i];
-        if (passMaybeUsed.framebuffersDepends.has(targetCreated.name)) {
+        if (passMaybeUsed.framebuffersDepends.has(targetCreated)) {
           this.framebufferDropList[i].push(targetCreated)
           return;
         }

--- a/src/render-graph/effect-composer.ts
+++ b/src/render-graph/effect-composer.ts
@@ -1,0 +1,45 @@
+import { RenderEngine, PassGraphNode, RenderGraph } from "../artgl";
+import { FrameBufferPool } from "./framebuffer-pool";
+import { RenderPass } from "./pass";
+import { PassDefine } from "./interface";
+
+export class EffectComposer {
+  constructor(engine: RenderEngine) {
+    this.engine = engine;
+    this.framebufferPool = new FrameBufferPool(this.engine);
+  }
+
+  private engine: RenderEngine;
+  private passes: RenderPass[] = [];
+  private nodeMap: Map<PassGraphNode, RenderPass> = new Map();
+  private framebufferPool: FrameBufferPool;
+
+  render(engine: RenderEngine, graph: RenderGraph) {
+    this.passes.forEach(pass => {
+      pass.execute(engine, graph, this.framebufferPool);
+    });
+  }
+
+  reset() {
+    this.passes = [];
+  }
+
+  addPass(pass: RenderPass) {
+    this.passes.push(pass);
+  }
+
+  registerNode(node: PassGraphNode, define: PassDefine ) {
+    const pass = new RenderPass(define)
+    this.nodeMap.set(node, pass);
+  }
+
+  clear() {
+    this.passes = [];
+    this.nodeMap.clear();
+  }
+
+  getPass(node: PassGraphNode): RenderPass {
+    return this.nodeMap.get(node);
+  }
+
+}

--- a/src/render-graph/framebuffer-pool.ts
+++ b/src/render-graph/framebuffer-pool.ts
@@ -4,10 +4,6 @@ import { generateUUID } from "../math";
 
 type formatKey = string;
 
-function buildFBOFormatKey(width: number, height: number, needDepth: boolean) {
-  return `${width}-${height}-${needDepth}`
-}
-
 export class FrameBufferPool{
   constructor(engine: RenderEngine) {
     this.engine = engine;
@@ -42,7 +38,7 @@ export class FrameBufferPool{
   * notify this fbo is not need to be keep, if input fbo has pooled before
   */
   discardFramebuffer(framebuffer: GLFramebuffer) {
-    this.availableBuffers.delete(framebuffer.formatKey);
+    this.availableBuffers.delete(framebuffer._formatKey);
 
   }
 
@@ -51,6 +47,11 @@ export class FrameBufferPool{
     if (!this.locked) {
       throw 'not fbo request before'
     }
+    if (needKeep) {
+      this.contentKeepBuffers.add(framebuffer)
+    } else {
+      this.availableBuffers.set(framebuffer._formatKey, framebuffer);
+    }
   }
 
   markFramebufferNotNeedKeepContent(framebuffer: GLFramebuffer) {
@@ -58,7 +59,7 @@ export class FrameBufferPool{
       throw 'this fbo is not content keeping'
     }
     this.contentKeepBuffers.delete(framebuffer);
-    this.availableBuffers.set(framebuffer.formatKey, framebuffer);
+    this.availableBuffers.set(framebuffer._formatKey, framebuffer);
   }
 
 }

--- a/src/render-graph/framebuffer-pool.ts
+++ b/src/render-graph/framebuffer-pool.ts
@@ -1,0 +1,64 @@
+import { GLFramebuffer } from "../webgl/gl-framebuffer";
+import { RenderEngine } from "../engine/render-engine";
+import { generateUUID } from "../math";
+
+type formatKey = string;
+
+function buildFBOFormatKey(width: number, height: number, needDepth: boolean) {
+  return `${width}-${height}-${needDepth}`
+}
+
+export class FrameBufferPool{
+  constructor(engine: RenderEngine) {
+    this.engine = engine;
+  }
+
+  private engine: RenderEngine;
+  availableBuffers: Map<formatKey, GLFramebuffer> = new Map();
+
+  contentKeepBuffers: Set<GLFramebuffer> = new Set();
+
+  locked: boolean = false;
+
+  /**
+   * get a GLFramebuffer from pool, if there is no fbo meet the config, create a new one, and pool it
+   */
+  requestFramebuffer(formatKey: formatKey, width: number, height: number, needDepth: boolean) {
+    if (this.locked) {
+      throw 'last requested fbo is not returned !'
+    }
+    const pooled = this.availableBuffers.get(formatKey);
+    if (pooled !== undefined) {
+      return pooled;
+    }
+    const FBOName = generateUUID();
+    const newFBO = this.engine.renderer.framebufferManager.createFrameBuffer(
+      this.engine, FBOName, width, height, needDepth);
+    this.locked = true;
+    return newFBO;
+  }
+
+  /**
+  * notify this fbo is not need to be keep, if input fbo has pooled before
+  */
+  discardFramebuffer(framebuffer: GLFramebuffer) {
+    this.availableBuffers.delete(framebuffer.formatKey);
+
+  }
+
+
+  returnFramebuffer(framebuffer: GLFramebuffer, needKeep: boolean) {
+    if (!this.locked) {
+      throw 'not fbo request before'
+    }
+  }
+
+  markFramebufferNotNeedKeepContent(framebuffer: GLFramebuffer) {
+    if (!this.contentKeepBuffers.has(framebuffer)) {
+      throw 'this fbo is not content keeping'
+    }
+    this.contentKeepBuffers.delete(framebuffer);
+    this.availableBuffers.set(framebuffer.formatKey, framebuffer);
+  }
+
+}

--- a/src/render-graph/framebuffer-pool.ts
+++ b/src/render-graph/framebuffer-pool.ts
@@ -22,7 +22,7 @@ export class FrameBufferPool {
 
   private engine: RenderEngine;
 
-  framebuffers: Map<FBOGeneratedName, GLFramebuffer>
+  framebuffers: Map<FBOGeneratedName, GLFramebuffer> = new Map();
 
   availableBuffers: Map<formatKey, GLFramebuffer> = new Map();
 

--- a/src/render-graph/framebuffer-pool.ts
+++ b/src/render-graph/framebuffer-pool.ts
@@ -1,52 +1,46 @@
 import { GLFramebuffer } from "../webgl/gl-framebuffer";
 import { RenderEngine } from "../engine/render-engine";
 import { generateUUID } from "../math";
+import { RenderTargetNode } from "./node/render-target-node";
 
 type formatKey = string;
+type FBOGeneratedName = string;
 
-export class FrameBufferPool{
+/**
+ * Proxy the fbo storage in rendergraph
+ */
+export class FrameBufferPool {
   constructor(engine: RenderEngine) {
     this.engine = engine;
   }
 
   private engine: RenderEngine;
+
+  framebuffers: Map<FBOGeneratedName, GLFramebuffer>
+
   availableBuffers: Map<formatKey, GLFramebuffer> = new Map();
 
   contentKeepBuffers: Set<GLFramebuffer> = new Set();
 
-  locked: boolean = false;
 
   /**
    * get a GLFramebuffer from pool, if there is no fbo meet the config, create a new one, and pool it
    */
-  requestFramebuffer(formatKey: formatKey, width: number, height: number, needDepth: boolean) {
-    if (this.locked) {
-      throw 'last requested fbo is not returned !'
-    }
-    const pooled = this.availableBuffers.get(formatKey);
+  requestFramebuffer(node: RenderTargetNode) {
+    const pooled = this.availableBuffers.get(node.formatKey);
     if (pooled !== undefined) {
       return pooled;
     }
     const FBOName = generateUUID();
     const newFBO = this.engine.renderer.framebufferManager.createFrameBuffer(
       this.engine, FBOName, width, height, needDepth);
-    this.locked = true;
     return newFBO;
   }
 
   /**
-  * notify this fbo is not need to be keep, if input fbo has pooled before
-  */
-  discardFramebuffer(framebuffer: GLFramebuffer) {
-    this.availableBuffers.delete(framebuffer._formatKey);
-
-  }
-
-
-  returnFramebuffer(framebuffer: GLFramebuffer, needKeep: boolean) {
-    if (!this.locked) {
-      throw 'not fbo request before'
-    }
+   * return a framebuffer that maybe request before, which will be pooling and reused 
+   */
+  returnFramebuffer(framebuffer: GLFramebuffer) {
     if (needKeep) {
       this.contentKeepBuffers.add(framebuffer)
     } else {
@@ -54,12 +48,13 @@ export class FrameBufferPool{
     }
   }
 
-  markFramebufferNotNeedKeepContent(framebuffer: GLFramebuffer) {
-    if (!this.contentKeepBuffers.has(framebuffer)) {
-      throw 'this fbo is not content keeping'
-    }
-    this.contentKeepBuffers.delete(framebuffer);
-    this.availableBuffers.set(framebuffer._formatKey, framebuffer);
+  /**
+    * notify this fbo is not need to be keep, if input fbo has pooled before
+    */
+  discardFramebuffer(node: RenderTargetNode) {
+    this.availableBuffers.delete(framebuffer._formatKey);
+
   }
+
 
 }

--- a/src/render-graph/interface.ts
+++ b/src/render-graph/interface.ts
@@ -35,6 +35,7 @@ export enum DimensionType {
 export interface RenderTargetDefine {
   name: string,
   from: () => Nullable<string>
+  keepContent?: () => boolean
   format?: {
     pixelFormat?: PixelFormat,
     dimensionType?: DimensionType,

--- a/src/render-graph/interface.ts
+++ b/src/render-graph/interface.ts
@@ -36,11 +36,11 @@ export interface RenderTargetDefine {
   name: string,
   from: () => Nullable<string>
   format?: {
-    pixelFormat: PixelFormat,
-    dimensionType: DimensionType,
+    pixelFormat?: PixelFormat,
+    dimensionType?: DimensionType,
     width?: number,
     height?: number,
-    disableDepthBuffer?: boolean
+    enableDepthBuffer?: boolean
   }
 }
 

--- a/src/render-graph/node/pass-graph-node.ts
+++ b/src/render-graph/node/pass-graph-node.ts
@@ -41,11 +41,14 @@ export class PassGraphNode extends DAGNode {
 
   // from updated graph structure, setup render pass
   updatePass(pass: RenderPass) {
-    pass.inputTarget.clear();
+    pass.uniformNameFBOMap.clear();
+    pass.framebuffersDepends.clear();
     Object.keys(this.inputs).forEach(inputKey => {
       const mapTo = this.inputs[inputKey];
-      pass.inputTarget.set(inputKey, mapTo)
+      pass.uniformNameFBOMap.set(inputKey, mapTo)
+      pass.framebuffersDepends.add(mapTo)
     })
+    pass.passNode = this;
   }
 
 }

--- a/src/render-graph/node/pass-graph-node.ts
+++ b/src/render-graph/node/pass-graph-node.ts
@@ -13,10 +13,13 @@ export class PassGraphNode extends DAGNode {
       this.inputsGetter = define.inputs;
     }
 
+    this.define = define;
+
   }
   private inputsGetter: Nullable<() => PassInputMapInfo> = null
   inputs: PassInputMapInfo = {}
   readonly name: string;
+  readonly define: PassDefine;
 
   // update graph structure
   updateDependNode(graph: RenderGraph) {

--- a/src/render-graph/node/render-target-node.ts
+++ b/src/render-graph/node/render-target-node.ts
@@ -80,11 +80,6 @@ export class RenderTargetNode extends DAGNode{
     return this._fromPassNode
   }
 
-  getOrCreateFrameBuffer(framebufferPool: FrameBufferPool): GLFramebuffer {
-    return framebufferPool.requestFramebuffer(
-      this.formatKey, this.widthAbs, this.heightAbs, this.enableDepth);
-  }
-
   private updateFormatKey() {
     this.formatKey = GLFramebuffer.buildFBOFormatKey(
       this.widthAbs, this.heightAbs, this.enableDepth

--- a/src/render-graph/node/render-target-node.ts
+++ b/src/render-graph/node/render-target-node.ts
@@ -7,7 +7,6 @@ import { RenderEngine } from "../../engine/render-engine";
 import { Nullable } from "../../type";
 import { Vector4 } from '../../math/vector4';
 import { PixelFormat } from "../../webgl/const";
-import { FrameBufferPool } from "../framebuffer-pool";
 import { RenderPass } from "../pass";
 import { PassGraphNode } from "./pass-graph-node";
 

--- a/src/render-graph/node/render-target-node.ts
+++ b/src/render-graph/node/render-target-node.ts
@@ -24,6 +24,10 @@ export class RenderTargetNode extends DAGNode{
       return
     }
 
+    if (define.keepContent === undefined) {
+      define.keepContent = () => false;
+    }
+
     // set a default format config
     if (define.format === undefined) {
       define.format = {
@@ -120,17 +124,10 @@ export class RenderTargetNode extends DAGNode{
     }
   }
 
-    // from updated graph structure, setup render pass
+  // from updated graph structure, setup render pass
   updatePass(engine: RenderEngine, pass: RenderPass) {
     this.updateSize(engine);
-    if (this.name === RenderGraph.screenRoot) {
-      pass.isOutputScreen = true;
-    } else {
-      pass.outputWidth = this.widthAbs;
-      pass.outputHeight = this.heightAbs;
-      pass.outputHasDepth = this.enableDepth;
-      pass.isOutputScreen = false;
-    }
+    pass.outputTarget = this;
   }
 
 }

--- a/src/render-graph/node/render-target-node.ts
+++ b/src/render-graph/node/render-target-node.ts
@@ -27,13 +27,20 @@ export class RenderTargetNode extends DAGNode{
         pixelFormat: PixelFormat.RGBA,
         dimensionType: DimensionType.bindRenderSize,
       }
+    } else {
+      if (define.format.pixelFormat === undefined) {
+        define.format.pixelFormat = PixelFormat.RGBA;
+      }
+      if (define.format.dimensionType === undefined) {
+        define.format.dimensionType = DimensionType.bindRenderSize;
+      }
     }
 
     if (define.format.dimensionType === DimensionType.bindRenderSize) {
       this.autoWidthRatio = define.format.width !== undefined ? MathUtil.clamp(define.format.width, 0, 1) : 1;
       this.autoHeightRatio = define.format.height !== undefined ? MathUtil.clamp(define.format.height, 0, 1) : 1;
     }
-    this.enableDepth = define.format.disableDepthBuffer !== undefined ? define.format.disableDepthBuffer : true;
+    this.enableDepth = define.format.enableDepthBuffer !== undefined ? define.format.enableDepthBuffer : false;
     
   }
   readonly isScreenNode: boolean;
@@ -44,7 +51,7 @@ export class RenderTargetNode extends DAGNode{
 
   autoWidthRatio: number = 0;
   autoHeightRatio: number = 0;
-  enableDepth: boolean = true;
+  enableDepth: boolean = false;
 
   widthAbs: number = 0;
   heightAbs: number = 0;

--- a/src/render-graph/pass.ts
+++ b/src/render-graph/pass.ts
@@ -90,7 +90,7 @@ export class RenderPass{
       engine.renderer.setRenderTarget(outputTarget);
       engine.renderer.state.setViewport(0, 0, this.outputTarget.widthAbs, this.outputTarget.heightAbs);
     }
-  
+    
     // input binding 
     if (this.overrideShading !== null) {
       engine.overrideShading = this.overrideShading;

--- a/src/render-graph/pass.ts
+++ b/src/render-graph/pass.ts
@@ -28,14 +28,6 @@ export class RenderPass{
 
   }
 
-  updateInputTargets(inputs: PassInputMapInfo) {
-    this.inputTarget.clear();
-    Object.keys(inputs).forEach(inputKey => {
-      const mapTo = inputs[inputKey];
-      this.inputTarget.set(inputKey, mapTo)
-    })
-  }
-
   readonly define: PassDefine;
   public name: string;
 
@@ -74,6 +66,14 @@ export class RenderPass{
       engine.renderFrameBuffer(framebuffer, debugInputViewport)
     })
   } 
+
+  updateInputTargets(inputs: PassInputMapInfo) {
+    this.inputTarget.clear();
+    Object.keys(inputs).forEach(inputKey => {
+      const mapTo = inputs[inputKey];
+      this.inputTarget.set(inputKey, mapTo)
+    })
+  }
 
   execute(engine: RenderEngine, graph: RenderGraph) {
 

--- a/src/render-graph/pass.ts
+++ b/src/render-graph/pass.ts
@@ -8,7 +8,7 @@ import { Shading } from "../core/shading";
 import { RenderTargetNode } from "./node/render-target-node";
 import { PassGraphNode } from "./node/pass-graph-node";
 
-type uniformName = string;
+export type uniformName = string;
 type framebufferName = string;
 
 export class RenderPass{
@@ -45,7 +45,8 @@ export class RenderPass{
   private overrideShading: Nullable<Shading> = null;
 
   uniformNameFBOMap: Map<uniformName, framebufferName> = new Map();
-  framebuffersDepends: Set<framebufferName> = new Set();
+  uniformRenderTargetNodeMap: Map<uniformName, RenderTargetNode> = new Map();
+  framebuffersDepends: Set<RenderTargetNode> = new Set();
 
   passNode: PassGraphNode
   // outputInfos
@@ -56,15 +57,14 @@ export class RenderPass{
   }
 
   renderDebugResult(engine: RenderEngine, graph: RenderGraph, framebuffer: GLFramebuffer) {
-    // const debugOutputViewport = graph.renderTargetNodes.get(this.outputFramebufferName).debugViewPort;
-    // engine.renderFrameBuffer(framebuffer, debugOutputViewport)
-    // // this will cause no use draw TODO optimize
-    // this.inputTarget.forEach((inputFramebufferName, _uniformName) => {
-    //   // this will break TODO
-    //   const framebuffer = engine.renderer.framebuffe rManager.getFramebuffer(inputFramebufferName);
-    //   const debugInputViewport = graph.renderTargetNodes.get(framebuffer.name).debugViewPort;
-    //   engine.renderFrameBuffer(framebuffer, debugInputViewport)
-    // })
+    const debugOutputViewport = this.outputTarget.debugViewPort;
+    engine.renderFrameBuffer(framebuffer, debugOutputViewport)
+    // this will cause no use draw TODO optimize
+    this.uniformNameFBOMap.forEach((inputFramebufferName, uniformName) => {
+      const dependFramebuffer = engine.renderer.framebufferManager.getFramebuffer(inputFramebufferName);
+      const debugInputViewport = this.uniformRenderTargetNodeMap.get(uniformName).debugViewPort;
+      engine.renderFrameBuffer(dependFramebuffer, debugInputViewport)
+    })
   } 
 
   execute(engine: RenderEngine, graph: RenderGraph, framebuffer: GLFramebuffer) {

--- a/src/render-graph/pass.ts
+++ b/src/render-graph/pass.ts
@@ -1,12 +1,10 @@
 import { GLFramebuffer } from "../webgl/gl-framebuffer";
 import { RenderEngine } from "../engine/render-engine";
-import { RenderGraph, RenderGraphNode } from "./render-graph";
-import { PassDefine, PassInputMapInfo } from "./interface";
-import { RenderTargetNode } from "./node/render-target-node";
+import { RenderGraph } from "./render-graph";
+import { PassDefine } from "./interface";
 import { Vector4 } from "../math/vector4";
 import { Nullable } from "../type";
 import { Shading } from "../core/shading";
-import { FrameBufferPool } from "./framebuffer-pool";
 
 type uniformName = string;
 type framebufferName = string;
@@ -54,18 +52,19 @@ export class RenderPass{
 
   isOutputScreen: boolean = true;
 
-  renderDebugResult(engine: RenderEngine, graph: RenderGraph) {
+  renderDebugResult(engine: RenderEngine, graph: RenderGraph, framebuffer: GLFramebuffer) {
     const debugOutputViewport = graph.renderTargetNodes.get(this.outputFramebufferName).debugViewPort;
-    engine.renderFrameBuffer(this.outputTarget, debugOutputViewport)
+    engine.renderFrameBuffer(framebuffer, debugOutputViewport)
     // this will cause no use draw TODO optimize
     this.inputTarget.forEach((inputFramebufferName, _uniformName) => {
-      const framebuffer = engine.renderer.framebufferManager.getFramebuffer(inputFramebufferName);
+      // this will break TODO
+      const framebuffer = engine.renderer.framebuffe rManager.getFramebuffer(inputFramebufferName);
       const debugInputViewport = graph.renderTargetNodes.get(framebuffer.name).debugViewPort;
       engine.renderFrameBuffer(framebuffer, debugInputViewport)
     })
   } 
 
-  execute(engine: RenderEngine, graph: RenderGraph, framebufferPool: FrameBufferPool) {
+  execute(engine: RenderEngine, graph: RenderGraph, framebuffer: GLFramebuffer) {
 
     this.checkIsValid();
     let outputTarget: GLFramebuffer;
@@ -84,7 +83,7 @@ export class RenderPass{
         engine.renderer.state.setFullScreenViewPort();
       }
     } else {
-      outputTarget = framebufferPool.requestFramebuffer()
+      outputTarget = framebuffer;
       engine.renderer.setRenderTarget(outputTarget);
       engine.renderer.state.setViewport(0, 0, this.outputWidth, this.outputHeight);
     }
@@ -131,7 +130,7 @@ export class RenderPass{
 
 
     if (graph.enableDebuggingView && !this.isOutputScreen) {
-      this.renderDebugResult(engine, graph);
+      this.renderDebugResult(engine, graph, framebuffer);
     }
 
   }

--- a/src/render-graph/render-graph.ts
+++ b/src/render-graph/render-graph.ts
@@ -3,48 +3,9 @@ import { PassGraphNode } from "./node/pass-graph-node";
 import { RenderTargetNode } from "./node/render-target-node";
 import { RenderEngine } from "../engine/render-engine";
 import { QuadSource } from './quad-source';
-import { RenderPass } from "./pass";
-import { FrameBufferPool } from "./framebuffer-pool";
-
+import { EffectComposer } from "./effect-composer";
 
 export type RenderGraphNode = PassGraphNode | RenderTargetNode;
-
-export class EffectComposer {
-
-  private passes: RenderPass[] = [];
-  private nodeMap: Map<PassGraphNode, RenderPass> = new Map();
-
-  render(engine: RenderEngine, graph: RenderGraph) {
-    this.passes.forEach(pass => {
-      pass.execute(engine, graph);
-    });
-  }
-
-  reset() {
-    this.passes = [];
-  }
-
-  addPass(pass: RenderPass) {
-    this.passes.push(pass);
-  }
-
-  registerNode(node: PassGraphNode, define: PassDefine ) {
-    const pass = new RenderPass(define)
-    this.nodeMap.set(node, pass);
-  }
-
-  clear() {
-    this.passes = [];
-    this.nodeMap.clear();
-  }
-
-  getPass(node: PassGraphNode): RenderPass {
-    return this.nodeMap.get(node);
-  }
-
-}
-
-
 
 export class RenderGraph {
 
@@ -85,7 +46,7 @@ export class RenderGraph {
   /**
    * Update the pass queue from current graph configure
    */
-  update(engine: RenderEngine, composer: EffectComposer, framebufferPool: FrameBufferPool) {
+  update(engine: RenderEngine, composer: EffectComposer) {
     
     //updateNodesConnection
     this.passNodes.forEach(node => {
@@ -95,7 +56,7 @@ export class RenderGraph {
       node.updateDependNode(this);
     });
 
-    // update pass queue
+    // create and update pass queue
     const nodeQueue = this.screenNode.generateDependencyOrderList() as RenderGraphNode[];
     composer.reset();
     nodeQueue.forEach(node => {

--- a/src/render-graph/render-graph.ts
+++ b/src/render-graph/render-graph.ts
@@ -58,17 +58,18 @@ export class RenderGraph {
 
     // create and update pass queue
     const nodeQueue = this.screenNode.generateDependencyOrderList() as RenderGraphNode[];
-    composer.reset();
+    const passes = [];
     nodeQueue.forEach(node => {
       if (node instanceof PassGraphNode) {
         const pass = composer.getPass(node);
         node.updatePass(pass);
-        composer.addPass(pass);
+        passes.push(pass);
       } else if (node instanceof RenderTargetNode) {
         const pass = composer.getPass(node.fromPassNode);
         node.updatePass(engine, pass)
       }
     })
+    composer.setPasses(passes)
   }
 
   private constructPassGraph(passesDefine: PassDefine[], composer: EffectComposer) {

--- a/src/render-graph/render-graph.ts
+++ b/src/render-graph/render-graph.ts
@@ -67,11 +67,6 @@ export class RenderGraph {
     return nodes;
   }
 
-  /**
-   * Clear the graph pass info as needed
-   *
-   * @memberof RenderGraph
-   */
   reset() {
     this.renderTargetNodes.clear();
     this.passNodes.clear();
@@ -79,9 +74,6 @@ export class RenderGraph {
 
   /**
    * Setup a new Graph configuration
-   *
-   * @param {GraphDefine} graphDefine
-   * @memberof RenderGraph
    */
   defineGraph(composer: EffectComposer, graphDefine: GraphDefine): void {
     this.reset();
@@ -91,8 +83,6 @@ export class RenderGraph {
 
   /**
    * Update the pass queue from current graph configure
-   *
-   * @memberof RenderGraph
    */
   update(engine: RenderEngine, composer: EffectComposer) {
     

--- a/src/shading/basic-lib/exposurer.ts
+++ b/src/shading/basic-lib/exposurer.ts
@@ -41,8 +41,6 @@ export enum ToneMapType {
 
 }
 
-console.log(ToneMapType);
-
 export class ExposureController extends BaseEffectShading<ExposureController> {
 
   @MapUniform("toneMappingExposure")

--- a/src/webgl/framebuffer-manager.ts
+++ b/src/webgl/framebuffer-manager.ts
@@ -3,7 +3,7 @@ import { GLRenderer } from "./gl-renderer";
 import { GLReleasable } from '../type';
 import { RenderEngine } from "../engine/render-engine";
 
-export class GLFrameBufferManager implements GLReleasable{
+export class GLFrameBufferManager {
   constructor(renderer: GLRenderer) {
     this.renderer = renderer;
     this.gl = renderer.gl;
@@ -30,6 +30,10 @@ export class GLFrameBufferManager implements GLReleasable{
     return framebuffer;
   }
 
+  deleteFramebuffer(framebuffer: GLFramebuffer) {
+    this.framebuffers.delete(framebuffer.name);
+  }
+
   getFramebuffer(framebufferName: string) {
     return this.framebuffers.get(framebufferName);
   }
@@ -42,7 +46,7 @@ export class GLFrameBufferManager implements GLReleasable{
     return this.renderer.textureManger.getGLTexture(framebuffer.textureAttachedSlot[0]);
   }
 
-  releaseGL() {
-    
+  dispose() {
+    this.framebuffers.clear();
   }
 }

--- a/src/webgl/framebuffer-manager.ts
+++ b/src/webgl/framebuffer-manager.ts
@@ -1,6 +1,5 @@
 import { GLFramebuffer } from "./gl-framebuffer";
 import { GLRenderer } from "./gl-renderer";
-import { GLReleasable } from '../type';
 import { RenderEngine } from "../engine/render-engine";
 
 export class GLFrameBufferManager {

--- a/src/webgl/gl-framebuffer.ts
+++ b/src/webgl/gl-framebuffer.ts
@@ -56,6 +56,8 @@ export class GLFramebuffer {
   width: number;
   height: number;
 
+  formatKey: string;
+
   enableDepth: boolean = true;
   webglDepthBuffer: Nullable<WebGLRenderbuffer> = null;
   webglFrameBuffer: WebGLFramebuffer;

--- a/src/webgl/gl-framebuffer.ts
+++ b/src/webgl/gl-framebuffer.ts
@@ -40,6 +40,10 @@ function loadGLAttachmentPoints(gl: WebGLRenderingContext) {
 export type FramebufferReadBufferType = Uint8Array | Uint16Array | Float32Array;
 
 export class GLFramebuffer {
+  static buildFBOFormatKey(width: number, height: number, needDepth: boolean) {
+    return `${width}-${height}-${needDepth}`
+  }
+
   constructor(renderer: GLRenderer, name: string, width: number, height: number) {
     this.name = name;
     this.renderer = renderer;
@@ -56,7 +60,7 @@ export class GLFramebuffer {
   width: number;
   height: number;
 
-  formatKey: string;
+  _formatKey: string;
 
   enableDepth: boolean = true;
   webglDepthBuffer: Nullable<WebGLRenderbuffer> = null;

--- a/src/webgl/gl-framebuffer.ts
+++ b/src/webgl/gl-framebuffer.ts
@@ -52,6 +52,7 @@ export class GLFramebuffer {
     this.webglFrameBuffer = this.createGLFramebuffer();
     this.width = width;
     this.height = height;
+    this.updateFormatKey();
   }
   name: string;
   gl: WebGLRenderingContext;
@@ -67,6 +68,12 @@ export class GLFramebuffer {
   webglFrameBuffer: WebGLFramebuffer;
 
   textureAttachedSlot: FramebufferAttachTexture[] = [];
+
+  private updateFormatKey() {
+    this._formatKey = GLFramebuffer.buildFBOFormatKey(
+      this.width, this.height, this.enableDepth
+    );
+  }
 
   createGLFramebuffer() {
     const buffer = this.gl.createFramebuffer();
@@ -106,6 +113,7 @@ export class GLFramebuffer {
 
     this.disposeAttachedDepthBuffer();
     this.createAttachDepthBuffer();
+    this.updateFormatKey();
 
   }
 

--- a/src/webgl/gl-renderer.ts
+++ b/src/webgl/gl-renderer.ts
@@ -45,7 +45,7 @@ export class GLRenderer implements GLReleasable {
   private angleInstanceExt: Nullable<ANGLE_instanced_arrays> = null;
 
   // enable this will cause great performance issue
-  // only enable this when debug draw range issue
+  // only enable this in develope 
   enableRenderErrorCatch: boolean = false;
   enableUniformDiff: boolean = true;
 

--- a/src/webgl/gl-renderer.ts
+++ b/src/webgl/gl-renderer.ts
@@ -185,7 +185,7 @@ export class GLRenderer implements GLReleasable {
     this.attributeBufferManager.releaseGL();
     this.programManager.releaseGL();
     this.textureManger.releaseGL();
-    this.framebufferManager.releaseGL();
+    this.framebufferManager.dispose();
     this.vaoManager.releaseGL();
   }
 

--- a/viewer/src/RenderPipeline.ts
+++ b/viewer/src/RenderPipeline.ts
@@ -66,10 +66,16 @@ export class RenderPipeline{
         },
         {
           name: 'sceneResult',
+          format: {
+            enableDepthBuffer: true,
+          },
           from: () => 'SceneOrigin',
         },
         {
           name: 'depthResult',
+          format: {
+            enableDepthBuffer: true,
+          },
           from: () => 'Depth',
         },
         {

--- a/viewer/src/RenderPipeline.ts
+++ b/viewer/src/RenderPipeline.ts
@@ -85,18 +85,22 @@ export class RenderPipeline{
         },
         {
           name: 'TAAHistoryA',
+          keepContent: () => !this.isEvenTick,
           from: () => this.isEvenTick ? null : 'TAA',
         },
         {
           name: 'TAAHistoryB',
+          keepContent: () => this.isEvenTick,
           from: () => this.isEvenTick ? 'TAA' : null,
         },
         {
           name: 'TSSAOHistoryA',
+          keepContent: () => !this.isEvenTick,
           from: () => this.isEvenTick ? null : 'TSSAO',
         },
         {
           name: 'TSSAOHistoryB',
+          keepContent: () => this.isEvenTick,
           from: () => this.isEvenTick ? 'TSSAO' : null,
         },
       ],

--- a/viewer/src/RenderPipeline.ts
+++ b/viewer/src/RenderPipeline.ts
@@ -62,7 +62,6 @@ export class RenderPipeline{
   build(scene: Scene) {
     this.config = createConf(this.engine, this);
     this.graph.defineGraph(
-      this.composer,
       {
       renderTargets: [
         {

--- a/viewer/src/RenderPipeline.ts
+++ b/viewer/src/RenderPipeline.ts
@@ -41,6 +41,15 @@ export class RenderPipeline{
     return this.tickNum % 2 === 0;
   }
 
+  getFramebufferByName(name: string) {
+    const node = this.graph.getRenderTargetDependence(name);
+    const fbo = this.composer.getFramebuffer(node);
+    if (fbo === undefined) {
+      console.warn(`fbo ${name} has been optimized, to make it available, set keep content always true in render target node config`)
+    }
+    return fbo;
+  }
+
   render(scene: Scene) {
     this.tickNum++;
 

--- a/viewer/src/application.ts
+++ b/viewer/src/application.ts
@@ -74,7 +74,9 @@ export class Application {
   }
 
   pickColor(x: number, y: number) {
-    const f = this.engine.renderer.framebufferManager.getFramebuffer("sceneResult");
+    const f = this.pipeline.getFramebufferByName("sceneResult");
+    return;
+    // TODO
     const result = new Uint8Array(10);
     f.readPixels(
       x * this.engine.renderer.width,

--- a/viewer/src/application.ts
+++ b/viewer/src/application.ts
@@ -23,8 +23,8 @@ export class Application {
   initialize(canvas: HTMLCanvasElement) {
     this.el = canvas;
     this.engine = new RenderEngine(canvas);
-    this.pipeline = new RenderPipeline();
-    this.pipeline.build(this.engine, this.scene);
+    this.pipeline = new RenderPipeline(this.engine);
+    this.pipeline.build(this.scene);
     this.engine.camera.transform.position.set(20, 10, 10)
     this.orbitController = new OrbitController(this.engine.camera as PerspectiveCamera);
     this.orbitController.registerInteractor(this.engine.interactor);
@@ -66,7 +66,7 @@ export class Application {
     this.orbitController.update();
 
     this.engine.renderer.state.colorbuffer.setClearColor(this.backgroundColor);
-    this.pipeline.render(this.engine, this.scene);
+    this.pipeline.render(this.scene);
 
     this.afterRender.notifyObservers(this.engine);
     this.engine.renderer.stat.reset();


### PR DESCRIPTION
#29 

Add fbo-pooling for fbo request pooling. Request by format key, returned and pooling created before.

Extract effect-composer for graph execution and optimization. Compute fbo return pool list for a given pass array. Manage the content need kept fbo . Wrap the render-pass execution by provide it reused target fbo, and rebind the depends fbo key to uniform.

